### PR TITLE
Fix comment for inactivity timer

### DIFF
--- a/dashboard_renderer.js
+++ b/dashboard_renderer.js
@@ -6,7 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Inactivity Timer Logic ---
     let inactivityTimer;
-    const INACTIVITY_TIMEOUT_MS = 5 * 1000; // 1 minute (60000 ms)
+    const INACTIVITY_TIMEOUT_MS = 5 * 1000; // 5 seconds
 
     function resetInactivityTimer() {
         // console.log("DashboardRenderer: Activity detected, resetting inactivity timer.");


### PR DESCRIPTION
## Summary
- clarify the comment describing the inactivity timeout duration in `dashboard_renderer.js`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f4ab86f408321a760d85d569acb83