### PR TITLE
Add Jest and utils directory test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start:electron": "electron .",
     "start": "concurrently \"npm:watch:css\" \"npm:start:electron\"",
     "build": "tailwindcss -i ./src/input.css -o ./style.css --minify",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -17,6 +17,7 @@
     "autoprefixer": "^10.4.21",
     "concurrently": "^9.1.2",
     "electron": "^36.2.1",
+    "jest": "^29.7.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17"
   },

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,36 @@
+jest.mock('../main-process/config.js', () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'adhan-test-'));
+  global.__tmpRoot = tmpRoot;
+  global.__settingsDir = path.join(tmpRoot, 'settings');
+  global.__prayerTimesDir = path.join(tmpRoot, 'prayer-times');
+  global.__assetsDir = path.join(tmpRoot, 'assets');
+
+  return {
+    PRAYER_TIMES_BASE_DIR: global.__prayerTimesDir,
+    ASSETS_DIR: global.__assetsDir,
+    getSettingsDir: () => global.__settingsDir
+  };
+});
+
+const fs = require('fs');
+const path = require('path');
+const { ensureDirectoriesExist } = require('../main-process/utils');
+
+afterAll(() => {
+  fs.rmSync(global.__tmpRoot, { recursive: true, force: true });
+});
+
+describe('ensureDirectoriesExist', () => {
+  test('creates required directories', () => {
+    ensureDirectoriesExist();
+
+    expect(fs.existsSync(global.__settingsDir)).toBe(true);
+    expect(fs.existsSync(global.__prayerTimesDir)).toBe(true);
+    expect(fs.existsSync(path.join(global.__assetsDir, 'audios'))).toBe(true);
+    expect(fs.existsSync(path.join(global.__assetsDir, 'images'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- install Jest for testing and configure npm `test` script
- add a unit test for `ensureDirectoriesExist`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f4ac4b5748321bb8eeae87ff25f91